### PR TITLE
Modify worker cleanup

### DIFF
--- a/src/Internal/InputTypesFunctions.luau
+++ b/src/Internal/InputTypesFunctions.luau
@@ -52,7 +52,9 @@ return {
 			end
 		end)
 
-		return Worker.New(RenderUsage)
+		return Worker.New(function()
+			RenderUsage:Disconnect()
+		end)
 	end,
 	[InputTypesEnums.RightClick] = function(
 		self: InterfaceWorksObject,
@@ -98,7 +100,9 @@ return {
 			end
 		end)
 
-		return Worker.New(RenderUsage)
+		return Worker.New(function()
+			RenderUsage:Disconnect()
+		end)
 	end,
 	[InputTypesEnums.Focus] = function(self: InterfaceWorksObject, Callback: (self: InterfaceWorksObject) -> ...any)
 		if self.Host:IsA("TextBox") then

--- a/src/Objects/Material.luau
+++ b/src/Objects/Material.luau
@@ -14,7 +14,7 @@ MaterialObject.__index = setmetatable(MaterialObject, BaseObject)
 
 function MaterialObject.New(
 	DefaultProperties: { [string | "Default"]: { [string]: any } },
-	Reactivity: (InterfaceWorksObject) -> ...RBXScriptConnection?,
+	Reactivity: (InterfaceWorksObject) -> ...() -> (),
 	ConstantReactivity: (InterfaceWorksObject) -> ()?
 ): InterfaceWorksMaterial
 	local NewBaseObject = BaseObject.New()

--- a/src/Objects/Worker.luau
+++ b/src/Objects/Worker.luau
@@ -18,7 +18,7 @@ function Worker.New(...): InterfaceWorksWorker
 
 	NewWorker.SelfProcesses = {}
 
-	for i, v: RBXScriptConnection | () -> () in { ... } do
+	for i, v: () -> () in { ... } do
 		NewWorker.SelfProcesses[i] = v
 	end
 
@@ -26,16 +26,16 @@ function Worker.New(...): InterfaceWorksWorker
 end
 
 function Worker:Destroy()
-	for _, v: RBXScriptConnection in pairs(self.SelfProcesses) do
-		v:Disconnect()
+	for _, v: () -> () in pairs(self.SelfProcesses) do
+		v()
 	end
 
 	self:__Destroy()
 end
 
 function Worker:Disconnect()
-	for _, v: RBXScriptConnection in pairs(self.SelfProcesses) do
-		v:Disconnect()
+	for _, v: () -> () in pairs(self.SelfProcesses) do
+		v()
 	end
 
 	self:__Destroy()

--- a/src/Public/MaterialController.luau
+++ b/src/Public/MaterialController.luau
@@ -8,7 +8,7 @@ local Materials = {}
 
 function Materials.New(
 	DefaultProperties: { [string | "Default"]: { [string]: any } },
-	Reactivity: (InterfaceWorksObject) -> ...RBXScriptConnection?,
+	Reactivity: (InterfaceWorksObject) -> ...() -> (),
 	ConstantReactivity: (InterfaceWorksObject) -> ()?
 ): InterfaceWorksMaterial
 	local NewMaterialObject = MaterialObject.New(DefaultProperties, Reactivity, ConstantReactivity)


### PR DESCRIPTION
Workers now work with custom cleanups. Instead of only disconnecting RBXScriptConnections, workers now call functions for cleanup at their destruction.